### PR TITLE
Fix support for shared libprotobuf in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(b64 PUBLIC ${CRYPTOPP_INCLUDE_DIRS} ${CMAKE_CURRENT_B
 ### Link libraries. These are configured through 3rdparty/${lib_name}
 target_link_libraries(typtopdb cryptopp)
 target_link_libraries(typtop typtopdb cryptopp zxcvbn typtopdb curl)
-target_link_libraries(b64 typtopdb ${PROTOBUF_STATIC_LIB})
+target_link_libraries(b64 typtopdb)
 
 ### Make sure cryptopp and zxcvbn are built when necessary.
 add_dependencies(typtopdb cryptopp zxcvbn)
@@ -51,14 +51,18 @@ add_dependencies(typtopdb cryptopp zxcvbn)
 if(CMAKE_PREFER_SHARED_LIBRARIES)
     if(PROTOBUF_SHARED_LIB)
         target_link_libraries(typtop ${PROTOBUF_SHARED_LIB})
+        target_link_libraries(b64 ${PROTOBUF_SHARED_LIB})
     else(PROTOBUF_STATIC_LIB)
         target_link_libraries(typtop ${PROTOBUF_STATIC_LIB})
+        target_link_libraries(b64 ${PROTOBUF_STATIC_LIB})
     endif()
 else()
     if(PROTOBUF_STATIC_LIB)
         target_link_libraries(typtop ${PROTOBUF_STATIC_LIB})
+        target_link_libraries(b64 ${PROTOBUF_STATIC_LIB})
     else(PROTOBUF_SHARED_LIB)
         target_link_libraries(typtop ${PROTOBUF_SHARED_LIB})
+        target_link_libraries(b64 ${PROTOBUF_SHARED_LIB})
     endif()
 endif()
 # ### --- INSTALL --- ###


### PR DESCRIPTION
Previously `cmake` would fail when relying on a shared `libprotobuf.so`, since it would always attempt to depend on `PROTOBUF_STATIC_LIB` (which is not set if `libprotobuf.a` is unavailable).

Possibly related to the more general "Cleanup cmake" todo, but it seemed like something that was worth an in-place patch as it prevented compilation on my machine.